### PR TITLE
Fix BPM initial value

### DIFF
--- a/lib/pages/music_play_screen.dart
+++ b/lib/pages/music_play_screen.dart
@@ -91,6 +91,7 @@ class _MusicPlayScreenState extends State<MusicPlayScreen> {
                     child: BpmControl(
                       minBpm: 20,
                       maxBpm: 240,
+                      initialBpm: _currentBpm,
                       onBpmChanged: (bpm) {
                         _currentBpm = bpm;
                       },

--- a/lib/widgets/bpm_control.dart
+++ b/lib/widgets/bpm_control.dart
@@ -3,11 +3,13 @@ import 'package:flutter/material.dart';
 class BpmControl extends StatefulWidget {
   final int minBpm;
   final int maxBpm;
+  final int initialBpm;
   final ValueChanged<int>? onBpmChanged; // <---
   const BpmControl({
     super.key,
     this.minBpm = 30,
     this.maxBpm = 240,
+    this.initialBpm = 60,
     this.onBpmChanged,
   });
 
@@ -21,7 +23,10 @@ class _BpmControlState extends State<BpmControl> {
   @override
   void initState() {
     super.initState();
-    _bpm = widget.maxBpm.clamp(widget.minBpm, widget.maxBpm);
+    _bpm = widget.initialBpm.clamp(widget.minBpm, widget.maxBpm);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.onBpmChanged?.call(_bpm);
+    });
   }
 
   void _incrementBpm() {


### PR DESCRIPTION
## Summary
- set initialBPM via BpmControl parameter and expose `initialBpm`
- use `initialBpm` in MusicPlayScreen

## Testing
- `dart format lib/widgets/bpm_control.dart lib/pages/music_play_screen.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441605819c83328796df64d99922df