### PR TITLE
chore: clean up stale comment in MidiPlayer

### DIFF
--- a/lib/models/midi_player.dart
+++ b/lib/models/midi_player.dart
@@ -17,8 +17,6 @@ class MidiPlayer {
   // Variable to store the Soundfont ID
   int? _soundfontId;
 
-  // Variable to track the index of the currently playing note event
-
   // --- Load SoundFont ---
   Future<void> loadSoundfont() async {
     if (_soundfontId != null) {


### PR DESCRIPTION
## Summary
- remove obsolete comment referencing a non-existent variable in `MidiPlayer`

## Testing
- `flutter format lib/models/midi_player.dart` *(fails: command not found)*
- `dart format lib/models/midi_player.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684417e76e688332a513a97405d4ab52