### PR TITLE
Fix provider lookup in dispose

### DIFF
--- a/lib/widgets/measure_card.dart
+++ b/lib/widgets/measure_card.dart
@@ -14,22 +14,25 @@ class MeasureCard extends StatefulWidget {
 }
 
 class _MeasureCardState extends State<MeasureCard> {
+  late final MusicPlayNotifier _musicPlayNotifier;
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _musicPlayNotifier = Provider.of<MusicPlayNotifier>(context, listen: false);
+  }
+
   @override
   initState() {
     super.initState();
     // Initialize any state or variables if needed
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final musicPlayNotifier =
-          Provider.of<MusicPlayNotifier>(context, listen: false);
-      musicPlayNotifier.addListener(_scrollToPosition);
+      _musicPlayNotifier.addListener(_scrollToPosition);
     });
   }
 
   @override
   void dispose() {
-    final musicPlayNotifier =
-        Provider.of<MusicPlayNotifier>(context, listen: false);
-    musicPlayNotifier.removeListener(_scrollToPosition);
+    _musicPlayNotifier.removeListener(_scrollToPosition);
     _scrollController.dispose();
     super.dispose();
   }

--- a/lib/widgets/part_widget.dart
+++ b/lib/widgets/part_widget.dart
@@ -15,15 +15,20 @@ class PartWidget extends StatefulWidget {
 
 class _PartWidgetState extends State<PartWidget> {
   final ScrollController _scrollController = ScrollController();
+  late final MusicPlayNotifier _musicPlayNotifier;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _musicPlayNotifier = Provider.of<MusicPlayNotifier>(context, listen: false);
+  }
 
   @override
   void initState() {
     super.initState();
     // Initialize the MusicPlayNotifier with the provided measures
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final musicPlayNotifier =
-          Provider.of<MusicPlayNotifier>(context, listen: false);
-      musicPlayNotifier.addListener(_scrollToCurrentMeasure);
+      _musicPlayNotifier.addListener(_scrollToCurrentMeasure);
     });
   }
 
@@ -47,11 +52,9 @@ class _PartWidgetState extends State<PartWidget> {
 
   @override
   void dispose() {
-    final musicPlayNotifier =
-        Provider.of<MusicPlayNotifier>(context, listen: false);
-    musicPlayNotifier.removeListener(_scrollToCurrentMeasure);
+    _musicPlayNotifier.removeListener(_scrollToCurrentMeasure);
     _scrollController.dispose();
-    musicPlayNotifier.stop();
+    _musicPlayNotifier.stop();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- avoid accessing Provider in dispose by caching notifier in state
- cache `MusicPlayNotifier` in both `MeasureCard` and `PartWidget`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684561969fe083329b26c39484f32bab