### PR TITLE
Parallel playback per measure

### DIFF
--- a/lib/models/music_player_notifier.dart
+++ b/lib/models/music_player_notifier.dart
@@ -32,17 +32,20 @@ class MusicPlayNotifier extends ChangeNotifier {
         .map((part) => part.measures.length)
         .reduce((a, b) => a > b ? a : b);
 
-    for (int i = 0; i < measureSize; i++) {
+    for (int i = 0; i < measureSize && _isPlaying; i++) {
+      measureIndex = i;
+
+      final List<Future<void>> measureFutures = [];
       for (final part in parts) {
-        if (i < part.measures.length) {
-          measureIndex = i;
-          final measure = part.measures[i];
-
-          await _playMeasure(measure, beatDurationMs);
-
-          if (!_isPlaying) break;
-        }
         if (!_isPlaying) break;
+        if (i < part.measures.length) {
+          final measure = part.measures[i];
+          measureFutures.add(_playMeasure(measure, beatDurationMs));
+        }
+      }
+
+      if (measureFutures.isNotEmpty) {
+        await Future.wait(measureFutures);
       }
     }
 


### PR DESCRIPTION
## Summary
- update `MusicPlayNotifier.play` to play part measures concurrently

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format lib/models/music_player_notifier.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684569d0a9c083328bcac9b2f50f9cbc